### PR TITLE
Use custom AsString implementations recursively

### DIFF
--- a/src/main/java/org/quicktheories/quicktheories/generators/Arrays.java
+++ b/src/main/java/org/quicktheories/quicktheories/generators/Arrays.java
@@ -1,9 +1,11 @@
 package org.quicktheories.quicktheories.generators;
 
-import java.lang.reflect.Array;
-
 import org.quicktheories.quicktheories.api.AsString;
 import org.quicktheories.quicktheories.core.Source;
+
+import java.lang.reflect.Array;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 final class Arrays {
 
@@ -17,11 +19,11 @@ final class Arrays {
                                                            // zero is less than
                                                            // the length of the
                                                            // array
-            a -> java.util.Arrays.asList(a)).describedAs(arrayDescriber());
+            a -> java.util.Arrays.asList(a)).describedAs(arrayDescriber(values::asString));
   }
   
-  private static <T> AsString<T[]> arrayDescriber() {
-    return a -> java.util.Arrays.deepToString(a);
+  private static <T> AsString<T[]> arrayDescriber(Function<T, String> valueDescriber) {
+    return a -> java.util.Arrays.stream(a).map(valueDescriber).collect(Collectors.joining(", ", "[", "]"));
   }
 
 }

--- a/src/main/java/org/quicktheories/quicktheories/generators/Lists.java
+++ b/src/main/java/org/quicktheories/quicktheories/generators/Lists.java
@@ -48,7 +48,8 @@ final class Lists {
         .stream()
         .map(p -> generator.next(p, step))
         .collect(collector)).withShrinker(
-            shrinkBoundedList(generator, collector, minimumSize));
+            shrinkBoundedList(generator, collector, minimumSize))
+            .describedAs(list -> list.stream().map(generator::asString).collect(arrayListCollector()).toString());
   }
   
   static Shrink<List<Integer>> swapBetweenShrinkMethodsForBoundedIntegerLists(

--- a/src/main/java/org/quicktheories/quicktheories/generators/Lists.java
+++ b/src/main/java/org/quicktheories/quicktheories/generators/Lists.java
@@ -4,11 +4,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.quicktheories.quicktheories.api.AsString;
 import org.quicktheories.quicktheories.core.Source;
 import org.quicktheories.quicktheories.core.Shrink;
 import org.quicktheories.quicktheories.core.ShrinkContext;
@@ -49,9 +52,13 @@ final class Lists {
         .map(p -> generator.next(p, step))
         .collect(collector)).withShrinker(
             shrinkBoundedList(generator, collector, minimumSize))
-            .describedAs(list -> list.stream().map(generator::asString).collect(arrayListCollector()).toString());
+            .describedAs(listDescriber(generator::asString));
   }
-  
+
+  private static <T> AsString<List<T>> listDescriber(Function<T, String> valueDescriber) {
+    return list -> list.stream().map(valueDescriber).collect(Collectors.joining(", ", "[", "]"));
+  }
+
   static Shrink<List<Integer>> swapBetweenShrinkMethodsForBoundedIntegerLists(
       Source<Integer> generator,
       Collector<Integer, List<Integer>, List<Integer>> collector,

--- a/src/test/java/org/quicktheories/quicktheories/generators/ArraysTest.java
+++ b/src/test/java/org/quicktheories/quicktheories/generators/ArraysTest.java
@@ -1,6 +1,8 @@
 package org.quicktheories.quicktheories.generators;
 
 import static org.junit.Assert.assertTrue;
+import static org.quicktheories.quicktheories.generators.Lists.arrayListCollector;
+import static org.quicktheories.quicktheories.generators.Lists.listsOf;
 import static org.quicktheories.quicktheories.generators.SourceAssert.assertThatSource;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -8,6 +10,9 @@ import org.junit.Test;
 import org.quicktheories.quicktheories.core.Configuration;
 import org.quicktheories.quicktheories.core.ShrinkContext;
 import org.quicktheories.quicktheories.core.Source;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ArraysTest {
 
@@ -110,6 +115,16 @@ public class ArraysTest {
         Integer.class, 2, 2);
     Integer[] anArray = { 1, 2, 3 };
     assertThat(testee.asString(anArray)).isEqualTo("[1, 2, 3]");
+  }
+
+  @Test
+  public void shouldDescribeListContentsUsingProvidedSource() {
+    Source<String> sourceWithCustomDescription = Arbitrary.constant("x").describedAs(x -> "custom description for x");
+    Source<String[]> testee = Arrays.arraysOf(sourceWithCustomDescription, String.class, 2, 2);
+
+    String[] anArray = { "foo", "bar"};
+
+    assertThat(testee.asString(anArray)).isEqualTo("[custom description for x, custom description for x]");
   }
 
   private <T> void isExpectedLength(T[] shrunkOutput, int expected) {

--- a/src/test/java/org/quicktheories/quicktheories/generators/ListsTest.java
+++ b/src/test/java/org/quicktheories/quicktheories/generators/ListsTest.java
@@ -1,5 +1,6 @@
 package org.quicktheories.quicktheories.generators;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.quicktheories.quicktheories.generators.IntegersTest.headsTowardsLowerAbsoluteValue;
 import static org.quicktheories.quicktheories.generators.Lists.arrayListCollector;
@@ -16,6 +17,7 @@ import java.util.function.Predicate;
 
 import org.junit.Test;
 import org.quicktheories.quicktheories.core.Configuration;
+import org.quicktheories.quicktheories.core.Generator;
 import org.quicktheories.quicktheories.core.ShrinkContext;
 import org.quicktheories.quicktheories.core.Source;
 
@@ -226,6 +228,14 @@ public class ListsTest {
                 generator, arrayListCollector(), 3));
     assertThatSource(testee).shrinksValueTo(Arrays.asList(15, 19, 1),
         Arrays.asList(14, 18, 1));
+  }
+
+  @Test
+  public void shouldDescribeListContentsUsingProvidedSource() {
+    Source<String> sourceWithCustomDescription = Arbitrary.constant("x").describedAs(x -> "custom description for x");
+    Source<List<String>> testee = listsOf(sourceWithCustomDescription, arrayListCollector(), 2, 3);
+    List<String> aList = new ArrayList<String>(Arrays.asList("x","x"));
+    assertThat(testee.asString(aList)).isEqualTo("[custom description for x, custom description for x]");
   }
 
   private void isLinkedListAfterShrinking(List<Integer> shrunkOutput) {


### PR DESCRIPTION
A `Source<T>` can have a custom `AsString<T>` to describe particular data
items.

However, if you then have a `Source<List<T>>`, you will not get the custom
`AsString<T>` behaviour, because it uses the default `List::toString`, which calls
the `T::toString` implementation instead.

This commit updates `Lists` to use the underlying source `AsString`
implementation rather than using List's default toString implementation.

(If this is a sensible idea, it could easily be extended to `Arrays`.)