### PR TITLE
Fix NPE in asString method

### DIFF
--- a/src/main/java/org/quicktheories/quicktheories/core/Source.java
+++ b/src/main/java/org/quicktheories/quicktheories/core/Source.java
@@ -197,7 +197,7 @@ public final class Source<T> implements Shrink<T>, Generator<T>, AsString<T> {
   }
   
   private static <T> AsString<T> defaultAsString() {
-    return (value) -> value.toString();
+    return (value) -> value == null ? "null" : value.toString();
   }
 
 

--- a/src/test/java/org/quicktheories/quicktheories/core/ToStringTest.java
+++ b/src/test/java/org/quicktheories/quicktheories/core/ToStringTest.java
@@ -158,7 +158,17 @@ public class ToStringTest {
           .hasMessageContaining(Arrays.deepToString(new Integer[] { 0 }));
     }
   }
-
+  
+  @Test
+  public void shouldPrintReadableRepresentationOfNull() throws Exception {
+      try {
+        qt().withFixedSeed(5).forAll(arbitrary().pick(null, "test")).check(value -> value != null);
+    } catch (final AssertionError error) {
+        assertThat(error)
+            .hasMessageContaining("null");
+    }
+  }
+  
   private void failIfReached() throws AssertionError {
     throw new Error("Expected an AssertionError but didn't get one");
   }


### PR DESCRIPTION
If shrinking a value yields null, it fails with NullPointerException rather than printing the smallest value. This can happen when using `arbitrary().pick(null, ...)`, for example.